### PR TITLE
Track .NET and Java Sample Usage

### DIFF
--- a/face/AndroidDetect/app/src/main/java/com/contoso/facetutorial/MainActivity.java
+++ b/face/AndroidDetect/app/src/main/java/com/contoso/facetutorial/MainActivity.java
@@ -27,9 +27,11 @@ public class MainActivity extends Activity {
     // Add your Face subscription key to your environment variables.
     private final String subscriptionKey = System.getenv("FACE_SUBSCRIPTION_KEY");
 
+    private final Header header = new Header("X-MS-AZSDK-Telemetry", "sample=android-detect");
     private final FaceClient faceServiceClient = new FaceClientBuilder()
             .endpoint(apiEndpoint)
             .credential(new AzureKeyCredential(subscriptionKey))
+            .clientOptions(new ClientOptions().setHeaders(Arrays.asList(header)))
             .buildClient();
 
     private final int PICK_IMAGE = 1;

--- a/face/DemoWPF/Sample-WPF/Controls/FaceServiceClientHelper.cs
+++ b/face/DemoWPF/Sample-WPF/Controls/FaceServiceClientHelper.cs
@@ -28,9 +28,19 @@ using System.Windows;
 using System.Windows.Controls;
 using Azure;
 using Azure.AI.Vision.Face;
+using Azure.Core.Pipeline;
+using Azure.Core;
 
 namespace Microsoft.ProjectOxford.Face.Controls
 {
+    internal class SampleUsageTrackingPolicy : HttpPipelineSynchronousPolicy
+    {
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            message.Request.Headers.Add("X-MS-AZSDK-Telemetry", "sample=demo-wpf");
+        }
+    }
+
     public static class FaceServiceClientHelper
     {
         /// <summary>
@@ -74,7 +84,9 @@ namespace Microsoft.ProjectOxford.Face.Controls
                 {
                     if (_subscriptionKey != subscriptionKey || _subscriptionEndpoint != subscriptionEndpoint || _instance == null)
                     {
-                        _instance = new FaceClient(new Uri(subscriptionEndpoint), new AzureKeyCredential(subscriptionKey));
+                        var clientOptions = new AzureAIVisionFaceClientOptions();
+                        clientOptions.AddPolicy(new SampleUsageTrackingPolicy(), HttpPipelinePosition.PerCall);
+                        _instance = new FaceClient(new Uri(subscriptionEndpoint), new AzureKeyCredential(subscriptionKey), clientOptions);
 
                         _subscriptionKey = subscriptionKey;
                         _subscriptionEndpoint = subscriptionEndpoint;

--- a/face/PortraitProcessing/java/PortraitProcessing.java
+++ b/face/PortraitProcessing/java/PortraitProcessing.java
@@ -21,6 +21,8 @@ import com.azure.ai.vision.face.models.FaceDetectionResult;
 import com.azure.ai.vision.face.models.FaceRecognitionModel;
 import com.azure.core.credential.KeyCredential;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Header;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -91,7 +93,8 @@ public class PortraitProcessing {
         imageMemoryStreamWriter.dispose();
 
         // Detect faces in the image
-        FaceClient faceClient = new FaceClientBuilder().endpoint(FACE_ENDPOINT).credential(new KeyCredential(FACE_KEY)).buildClient();
+        ClientOptions clientOptions = new ClientOptions().setHeaders(Arrays.asList(new Header("X-MS-AZSDK-Telemetry", "sample=portrait-processing")));
+        FaceClient faceClient = new FaceClientBuilder().endpoint(FACE_ENDPOINT).credential(new KeyCredential(FACE_KEY)).clientOptions(clientOptions).buildClient();
         DetectOptions options = new DetectOptions(DETECTION_MODEL, RECO_MODEL, false).setReturnFaceAttributes(FACE_ATTRIBUTES).setReturnFaceLandmarks(true);
         List<FaceDetectionResult> detectedFaces = faceClient.detect(BinaryData.fromBytes(imageMemoryStream.toByteArray()), options);
 


### PR DESCRIPTION
Add the capability to track C# and Java sample usage, like how Python does (see https://github.com/Azure-Samples/azure-ai-vision/pull/9). We'll be using a customized [HttpPipelineSynchronousPolicy](https://learn.microsoft.com/dotnet/api/azure.core.pipeline.httppipelinesynchronouspolicy.onsendingrequest) (C#) and [ClientOptions](https://learn.microsoft.com/java/api/com.azure.core.util.clientoptions?#com-azure-core-util-clientoptions-setheaders(java-lang-iterable(com-azure-core-util-header))) (Java) to carry info in additional request header:

(Python)
```python
headers = {"X-MS-AZSDK-Telemetry": "sample=sample-name"}
with FaceClient(endpoint=URI, credential=AzureKeyCredential(KEY), headers=headers) as face_client:
```

(C#)
```cs
class SampleUsageTrackingPolicy : HttpPipelineSynchronousPolicy
{
    public override void OnSendingRequest(HttpMessage message)
    {
        message.Request.Headers.Add("X-MS-AZSDK-Telemetry", "sample=sample-name");
    }
}

var clientOptions = new AzureAIVisionFaceClientOptions();
clientOptions.AddPolicy(new SampleUsageTrackingPolicy(), HttpPipelinePosition.PerCall);
FaceClient faceClient = new FaceClient(new Uri(URI), new AzureKeyCredential(KEY), clientOptions);
```

(Java)
```java
Header header = new Header("X-MS-AZSDK-Telemetry", "sample=sample-name");
FaceClient faceServiceClient = new FaceClientBuilder()
        .endpoint(URI)
        .credential(new AzureKeyCredential(KEY))
        .clientOptions(new ClientOptions().setHeaders(Arrays.asList(header)))
        .buildClient();
```