### PR TITLE
Do Background Removal Locally Using ORT and BiRefNet

### DIFF
--- a/face/PortraitProcessing/README.md
+++ b/face/PortraitProcessing/README.md
@@ -1,7 +1,7 @@
 
 ## Portrait Processing
 
-The sample demonstrates how to make a portrait image out of an original image by using Azure Face API and Azure Background Removal API, as illustrated below:
+The sample demonstrates how to make a portrait image out of an original image by using Azure Face API and Background Removal, as illustrated below:
 
 | Input Image | Output Portrait | (Intermediate) Output Matting |
 | :-: | :-: | :-: |
@@ -11,9 +11,8 @@ The sample demonstrates how to make a portrait image out of an original image by
 ### Key Features
 
 * Learn how to call face detection API via SDK and retrieve facial attirbutes such us bounding box, head pose, blur level, quality, etc.
-* Use background removal service to get the foreground matting.
 * Optimize network lantency by down-scaling and compressing input image as JPEG stream.
-* Leverage "foregroundMatting" mode instead of "backgroundRemoval" when removing backround, and apply alpha channel locally. In this way we can minimize the data transmitted.
+* Leverage ONNX Runtime to run the BiRefNet image segmentation model and apply alpha channel locally.
 
 
 ### Steps Involved
@@ -22,3 +21,9 @@ The sample demonstrates how to make a portrait image out of an original image by
 2. Detect faces in the stream, and read the returned facial attributes. Optionally, check whether the face quality is suitable for portrait processing.
 3. Crop the face out from the image, and request for foreground matting of the focused area.
 4. Compose the transparent background portrait using the alpha matting and the face crop.
+
+
+### References
+
+* https://github.com/ZhengPeng7/BiRefNet
+* https://github.com/danielgatis/rembg

--- a/face/PortraitProcessing/csharp/BiRefNet.cs
+++ b/face/PortraitProcessing/csharp/BiRefNet.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using System.Drawing;
+
+namespace PortraitProcessing
+{
+    internal class BiRefNet
+    {
+        private InferenceSession _session;
+
+        internal BiRefNet()
+        {
+            _session = new InferenceSession("BiRefNet-portrait-epoch_150.onnx");
+        }
+
+        internal Bitmap Predict(Bitmap image)
+        {
+            // normalize input to (1, c=3, h=1024, w=1024)
+            Bitmap resized = new Bitmap(image, new Size(1024, 1024));
+            float scale = 1.0F;
+            for (int x = 0; x < resized.Width; x++)
+            {
+                for (int y = 0; y < resized.Height; y++)
+                {
+                    scale = Math.Max((float)resized.GetPixel(x, y).R, scale);
+                    scale = Math.Max((float)resized.GetPixel(x, y).G, scale);
+                    scale = Math.Max((float)resized.GetPixel(x, y).B, scale);
+                }
+            }
+            DenseTensor<float> tensor = new DenseTensor<float>([1, 3, resized.Height, resized.Width]);
+            for (int x = 0; x < resized.Width; x++)
+            {
+                for (int y = 0; y < resized.Height; y++)
+                {
+                    tensor[0, 0, y, x] = (((float)resized.GetPixel(x, y).R / scale) - 0.485F) / 0.229F;
+                    tensor[0, 1, y, x] = (((float)resized.GetPixel(x, y).G / scale) - 0.456F) / 0.224F;
+                    tensor[0, 2, y, x] = (((float)resized.GetPixel(x, y).B / scale) - 0.406F) / 0.225F;
+                }
+            }
+
+            // feed into the model
+            using IDisposableReadOnlyCollection<DisposableNamedOnnxValue> outputs = _session.Run([NamedOnnxValue.CreateFromTensor("input_image", tensor)]);
+
+            // normalize the (1, 1, h=1024, w=1024) output prediction
+            Tensor<float> pred = outputs.First().AsTensor<float>();
+            for (int x = 0; x < resized.Width; x++)
+            {
+                for (int y = 0; y < resized.Height; y++)
+                {
+                    pred[0, 0, y, x] = 1.0F / (1.0F + (float)Math.Exp(-pred[0, 0, y, x]));
+                }
+            }
+            float ma = pred.Max();
+            float mi = pred.Min();
+            for (int x = 0; x < resized.Width; x++)
+            {
+                for (int y = 0; y < resized.Height; y++)
+                {
+                    pred[0, 0, y, x] = (pred[0, 0, y, x] - mi) / (ma - mi);
+                }
+            }
+
+            // convert and resize the matting back to Bitmap object
+            Bitmap matting = new Bitmap(resized.Width, resized.Height);
+            for (int x = 0; x < resized.Width; x++)
+            {
+                for (int y = 0; y < resized.Height; y++)
+                {
+                    matting.SetPixel(x, y, Color.FromArgb((int)(pred[0, 0, y, x] * 255.0F), (int)(pred[0, 0, y, x] * 255.0F), (int)(pred[0, 0, y, x] * 255.0F)));
+                }
+            }
+            return new Bitmap(matting, new Size(image.Width, image.Height));
+        }
+    }
+}

--- a/face/PortraitProcessing/csharp/PortraitProcessing.csproj
+++ b/face/PortraitProcessing/csharp/PortraitProcessing.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.Vision.Face" Version="1.0.0-beta.1" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.19.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
 

--- a/face/PortraitProcessing/csharp/PortraitProcessing.sln
+++ b/face/PortraitProcessing/csharp/PortraitProcessing.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.34916.146
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortraitProcessing", "PortraitProcessing.csproj", "{CB46FB90-DA11-40C8-A086-CDBB0EC901E5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PortraitProcessing", "PortraitProcessing.csproj", "{CB46FB90-DA11-40C8-A086-CDBB0EC901E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/face/PortraitProcessing/csharp/README.md
+++ b/face/PortraitProcessing/csharp/README.md
@@ -2,8 +2,9 @@
 Run the C# project to get a processed portrait:
 
 ```console
+$ curl -L -O https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-portrait-epoch_150.onnx
 $ dotnet run
-Sample code for portrait processing with Azure Face API and Background Removal API.
+Sample code for portrait processing with Azure Face API and Background Removal.
 Number of faces detected: 1
 Face detected: width=150, height=194, left=258, top=80
 Head pose: yaw=0.6, pitch=-1.6, roll=3.4
@@ -18,19 +19,18 @@ End of the sample for portrait processing.
 * .NET for Windows
 * Face SDK: `dotnet add package Azure.AI.Vision.Face --prerelease`
 * Image Processing: `dotnet add package System.Drawing.Common`
+* ONNX Runtime: `dotnet add package Microsoft.ML.OnnxRuntime`
 
 
 ### Keys and Endpoints
 
-[Create a Face resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesFace) in the Azure portal and obtain a key and endpoint URL to call face detection API, and [a Vision resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesComputerVision) to call background removal API.
+[Create a Face resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesFace) in the Azure portal and obtain a key and endpoint URL to call face detection API.
 
 Set the keys and endponts as environment variables:
 
 ```cmd
 setx FACE_API_KEY <your_face_key>
 setx FACE_ENDPOINT_URL <your_face_endpoint>
-setx BACKGROUND_API_KEY <your_vision_key>
-setx BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```
 
 After you add the environment variables, you may need to restart any running programs that will read the environment variables, including the console window.

--- a/face/PortraitProcessing/csharp/SampleUsageTrackingPolicy.cs
+++ b/face/PortraitProcessing/csharp/SampleUsageTrackingPolicy.cs
@@ -1,0 +1,13 @@
+﻿using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace PortraitProcessing
+{
+    internal class SampleUsageTrackingPolicy : HttpPipelineSynchronousPolicy
+    {
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            message.Request.Headers.Add("X-MS-AZSDK-Telemetry", "sample=portrait-processing");
+        }
+    }
+}

--- a/face/PortraitProcessing/java/BiRefNet.java
+++ b/face/PortraitProcessing/java/BiRefNet.java
@@ -1,0 +1,80 @@
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import ai.onnxruntime.OrtSession.Result;
+
+public class BiRefNet {
+    private OrtEnvironment environment = null;
+    private OrtSession session = null;
+
+    public BiRefNet() throws OrtException {
+        environment = OrtEnvironment.getEnvironment();
+        session = environment.createSession("BiRefNet-portrait-epoch_150.onnx");
+    }
+
+    public BufferedImage predict(BufferedImage image) throws OrtException {
+        // normalize input to (1, c=3, h=1024, w=1024)
+        BufferedImage resized = getResizedBufferedImage(image, 1024, 1024);
+        float scale = 1.0F;
+        for (int x = 0; x < resized.getWidth(); x++) {
+            for (int y = 0; y < resized.getHeight(); y++) {
+                scale = Math.max((float) ((resized.getRGB(x, y) >> 16) & 0x000000FF), scale);
+                scale = Math.max((float) ((resized.getRGB(x, y) >> 8) & 0x000000FF), scale);
+                scale = Math.max((float) (resized.getRGB(x, y) & 0x000000FF), scale);
+            }
+        }
+        float[][][][] normalized = new float[1][3][resized.getHeight()][resized.getWidth()];
+        for (int x = 0; x < resized.getWidth(); x++) {
+            for (int y = 0; y < resized.getHeight(); y++) {
+                normalized[0][0][y][x] = (((float) ((resized.getRGB(x, y) >> 16) & 0x000000FF) / scale) - 0.485F) / 0.229F;
+                normalized[0][1][y][x] = (((float) ((resized.getRGB(x, y) >> 8) & 0x000000FF) / scale) - 0.456F) / 0.224F;
+                normalized[0][2][y][x] = (((float) (resized.getRGB(x, y) & 0x000000FF) / scale) - 0.406F) / 0.225F;
+            }
+        }
+
+        // feed into the model
+        OnnxTensor tensor = OnnxTensor.createTensor(environment, normalized);
+        Result outputs = session.run(Collections.singletonMap("input_image", tensor));
+
+        // normalize the (1, 1, h=1024, w=1024) output prediction
+        float[][][][] pred = (float[][][][]) outputs.get(0).getValue();
+        for (int x = 0; x < resized.getWidth(); x++) {
+            for (int y = 0; y < resized.getHeight(); y++) {
+                pred[0][0][y][x] = 1.0F / (1.0F + (float) Math.exp(-pred[0][0][y][x]));
+            }
+        }
+        float ma = (float) Arrays.stream(pred).flatMap(Arrays::stream).flatMap(Arrays::stream).flatMapToDouble(f -> IntStream.range(0, f.length).mapToDouble(i -> f[i])).max().orElseThrow();
+        float mi = (float) Arrays.stream(pred).flatMap(Arrays::stream).flatMap(Arrays::stream).flatMapToDouble(f -> IntStream.range(0, f.length).mapToDouble(i -> f[i])).min().orElseThrow();
+        for (int x = 0; x < resized.getWidth(); x++) {
+            for (int y = 0; y < resized.getHeight(); y++) {
+                pred[0][0][y][x] = (pred[0][0][y][x] - mi) / (ma - mi);
+            }
+        }
+
+        // convert and resize the matting back to BufferedImage object
+        BufferedImage matting = new BufferedImage(resized.getWidth(), resized.getHeight(), BufferedImage.TYPE_INT_RGB);
+        for (int x = 0; x < resized.getWidth(); x++) {
+            for (int y = 0; y < resized.getHeight(); y++) {
+                int value = (int) (pred[0][0][y][x] * 255.0F);
+                matting.setRGB(x, y, (value << 16) | (value << 8) | value);
+            }
+        }
+        return getResizedBufferedImage(matting, image.getWidth(), image.getHeight());
+    }
+
+    private BufferedImage getResizedBufferedImage(BufferedImage image, int width, int height) {
+        BufferedImage resized = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics graphics = resized.getGraphics();
+        graphics.drawImage(image.getScaledInstance(resized.getWidth(), resized.getHeight(), Image.SCALE_SMOOTH), 0, 0, null);
+        graphics.dispose();
+        return resized;
+    }
+}

--- a/face/PortraitProcessing/java/README.md
+++ b/face/PortraitProcessing/java/README.md
@@ -2,8 +2,9 @@
 Run the Java project to get a processed portrait:
 
 ```console
+$ curl -L -O https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-portrait-epoch_150.onnx
 $ gradlew run
-Sample code for portrait processing with Azure Face API and Background Removal API.
+Sample code for portrait processing with Azure Face API and Background Removal.
 Number of faces detected: 1
 Face detected: width=150, height=194, left=258, top=80
 Head pose: yaw=0.4, pitch=-1.1, roll=3.1
@@ -17,12 +18,12 @@ End of the sample for portrait processing.
 
 * Java JDK/JRE 11
 * Face SDK: `pkg:maven/com.azure/azure-ai-vision-face`
-* HTTP Client: `pkg:maven/org.apache.httpcomponents/httpclient`
+* ONNX Runtime: `pkg:maven/com.microsoft.onnxruntime/onnxruntime`
 
 
 ### Keys and Endpoints
 
-[Create a Face resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesFace) in the Azure portal and obtain a key and endpoint URL to call face detection API, and [a Vision resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesComputerVision) to call background removal API.
+[Create a Face resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesFace) in the Azure portal and obtain a key and endpoint URL to call face detection API.
 
 Set the keys and endponts as environment variables:
 
@@ -31,8 +32,6 @@ Set the keys and endponts as environment variables:
 ```cmd
 setx FACE_API_KEY <your_face_key>
 setx FACE_ENDPOINT_URL <your_face_endpoint>
-setx BACKGROUND_API_KEY <your_vision_key>
-setx BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```
 
 (For Linux)
@@ -40,8 +39,6 @@ setx BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```bash
 export FACE_API_KEY <your_face_key>
 export FACE_ENDPOINT_URL <your_face_endpoint>
-export BACKGROUND_API_KEY <your_vision_key>
-export BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```
 
 

--- a/face/PortraitProcessing/java/build.gradle
+++ b/face/PortraitProcessing/java/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     implementation 'com.azure:azure-ai-vision-face:1.0.0-beta.1'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'com.microsoft.onnxruntime:onnxruntime:1.19.0'
 }
 
 java {

--- a/face/PortraitProcessing/python/README.md
+++ b/face/PortraitProcessing/python/README.md
@@ -2,8 +2,9 @@
 Run the Python script to get a processed portrait:
 
 ```console
+$ curl -L -O https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-portrait-epoch_150.onnx
 $ python3 program.py
-Sample code for portrait processing with Azure Face API and Background Removal API.
+Sample code for portrait processing with Azure Face API and Background Removal.
 Number of faces detected: 1
 Face detected: width=150, height=194, left=258, top=80
 Head pose: yaw=0.4, pitch=-1.1, roll=3.1
@@ -19,11 +20,12 @@ End of the sample for portrait processing.
 * Python 3.8+
 * Face SDK: `python3 -m pip install azure-ai-vision-face`
 * Pillow (PIL): `python3 -m pip install pillow`
+* ONNX Runtime: `python3 -m pip install onnxruntime`
 
 
 ### Keys and Endpoints
 
-[Create a Face resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesFace) in the Azure portal and obtain a key and endpoint URL to call face detection API, and [a Vision resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesComputerVision) to call background removal API.
+[Create a Face resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesFace) in the Azure portal and obtain a key and endpoint URL to call face detection API.
 
 Set the keys and endponts as environment variables:
 
@@ -32,8 +34,6 @@ Set the keys and endponts as environment variables:
 ```cmd
 setx FACE_API_KEY <your_face_key>
 setx FACE_ENDPOINT_URL <your_face_endpoint>
-setx BACKGROUND_API_KEY <your_vision_key>
-setx BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```
 
 (For Linux)
@@ -41,8 +41,6 @@ setx BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```bash
 export FACE_API_KEY <your_face_key>
 export FACE_ENDPOINT_URL <your_face_endpoint>
-export BACKGROUND_API_KEY <your_vision_key>
-export BACKGROUND_ENDPOINT_URL <your_vision_endpoint>
 ```
 
 

--- a/face/PortraitProcessing/python/birefnet.py
+++ b/face/PortraitProcessing/python/birefnet.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import onnxruntime as ort
+import PIL
+
+class BiRefNet:
+
+    def __init__(self):
+        self.session = ort.InferenceSession("BiRefNet-portrait-epoch_150.onnx")
+
+    def predict(self, image: PIL.Image.Image) -> PIL.Image.Image:
+        # normalize input to (1, c=3, h=1024, w=1024)
+        normalized = image.convert("RGB").resize((1024, 1024), PIL.Image.Resampling.LANCZOS)
+        normalized = np.array(normalized).astype(np.float32)
+        normalized = normalized / np.max(normalized)
+        normalized[:, :, 0] = (normalized[:, :, 0] - 0.485) / 0.229
+        normalized[:, :, 1] = (normalized[:, :, 1] - 0.456) / 0.224
+        normalized[:, :, 2] = (normalized[:, :, 2] - 0.406) / 0.225
+        normalized = np.expand_dims(normalized.transpose((2, 0, 1)), 0)
+
+        # feed into the model
+        outputs = self.session.run(None, {"input_image": normalized})
+
+        # normalize the (1, 1, h=1024, w=1024) output prediction
+        pred = 1 / (1 + np.exp(-outputs[0][0, 0, :, :]))
+        ma = np.max(pred)
+        mi = np.min(pred)
+        pred = (pred - mi) / (ma - mi)
+
+        # convert and resize the matting back to PIL object
+        matting = PIL.Image.fromarray((pred * 255).astype(np.uint8), mode="L")
+        return matting.resize(image.size, PIL.Image.Resampling.LANCZOS)


### PR DESCRIPTION
The PR migrates the background removal solution of portrait processing from cloud-based Azure Segment API to a local BiRefNet model:

* https://github.com/ZhengPeng7/BiRefNet (MIT License)
* ["Bilateral Reference for High-Resolution Dichotomous Image Segmentation" (CAAI AIR 2024)](https://arxiv.org/pdf/2401.03407)

Here we are using the customed version trained specifically for human portrait matting, following the same prepropressing and postprocessing steps implemented by [Python rembg library](https://pypi.org/project/rembg/):

* https://github.com/danielgatis/rembg (MIT License)
* https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-portrait-epoch_150.onnx
* https://github.com/danielgatis/rembg/blob/95b81143c9a1d760c892ffa7f406f055fc244b81/rembg/sessions/base.py#L40-L65
* https://github.com/danielgatis/rembg/blob/95b81143c9a1d760c892ffa7f406f055fc244b81/rembg/sessions/birefnet_general.py#L20-L50

And port the mechanism to C# and Java which also support ONNX Runtime.
