### PR TITLE
Update Android/WPF Demo and Portrait Processing to SDK 1.0.0 Beta.2

### DIFF
--- a/face/AndroidDetect/README.md
+++ b/face/AndroidDetect/README.md
@@ -16,7 +16,7 @@ The sample demonstrates how to use Azure Face API to detect and frame faces in a
 ### Prerequisites
 
 * [Android Studio](https://developer.android.com/studio) (API Level 28+)
-* Java SDK `com.azure:azure-ai-vision-face:1.0.0-beta.1` for Gradle
+* Java SDK `com.azure:azure-ai-vision-face:1.0.0-beta.2` for Gradle
 
 
 ### Setup and Build

--- a/face/AndroidDetect/app/build.gradle
+++ b/face/AndroidDetect/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.application'
 
 android {
     namespace 'com.contoso.facetutorial'
-    compileSdkVersion 33
+    compileSdk 34
     defaultConfig {
         minSdkVersion 28
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.4.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -26,7 +26,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
 
-    implementation 'com.azure:azure-ai-vision-face:1.0.0-beta.1'
+    implementation 'com.azure:azure-ai-vision-face:1.0.0-beta.2'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/face/AndroidDetect/build.gradle
+++ b/face/AndroidDetect/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'com.android.tools.build:gradle:8.3.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/face/DemoWPF/Sample-WPF/App.config
+++ b/face/DemoWPF/Sample-WPF/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
@@ -31,11 +31,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.10" newVersion="6.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/face/DemoWPF/Sample-WPF/FaceAPI-WPF-Samples.csproj
+++ b/face/DemoWPF/Sample-WPF/FaceAPI-WPF-Samples.csproj
@@ -55,13 +55,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Azure.AI.Vision.Face, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>packages\Azure.AI.Vision.Face.1.0.0-beta.1\lib\netstandard2.0\Azure.AI.Vision.Face.dll</HintPath>
+      <HintPath>packages\Azure.AI.Vision.Face.1.0.0-beta.2\lib\netstandard2.0\Azure.AI.Vision.Face.dll</HintPath>
     </Reference>
-    <Reference Include="Azure.Core, Version=1.39.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>packages\Azure.Core.1.39.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.44.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>packages\Azure.Core.1.44.1\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Rest.ClientRuntime.2.3.24\lib\net461\Microsoft.Rest.ClientRuntime.dll</HintPath>
@@ -76,8 +76,8 @@
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>packages\System.ClientModel.1.0.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.1.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>packages\System.ClientModel.1.1.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=6.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -87,8 +87,8 @@
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=1.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Memory.Data.1.0.2\lib\net461\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.Data.6.0.0\lib\net461\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
@@ -110,11 +110,11 @@
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.4.7.2\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=6.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.6.0.10\lib\net461\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/face/DemoWPF/Sample-WPF/packages.config
+++ b/face/DemoWPF/Sample-WPF/packages.config
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Azure.AI.Vision.Face" version="1.0.0-beta.1" targetFramework="net48" />
-  <package id="Azure.Core" version="1.39.0" targetFramework="net48" />
+  <package id="Azure.AI.Vision.Face" version="1.0.0-beta.2" targetFramework="net48" />
+  <package id="Azure.Core" version="1.44.1" targetFramework="net48" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net48" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.24" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.ClientModel" version="1.0.0" targetFramework="net48" />
+  <package id="System.ClientModel" version="1.1.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
-  <package id="System.Memory.Data" version="1.0.2" targetFramework="net48" />
+  <package id="System.Memory.Data" version="6.0.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net48" />
-  <package id="System.Text.Json" version="4.7.2" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="6.0.10" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/face/Scenario-PortraitProcessing/csharp/PortraitProcessing.csproj
+++ b/face/Scenario-PortraitProcessing/csharp/PortraitProcessing.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.Vision.Face" Version="1.0.0-beta.1" />
+    <PackageReference Include="Azure.AI.Vision.Face" Version="1.0.0-beta.2" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.19.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>

--- a/face/Scenario-PortraitProcessing/java/build.gradle
+++ b/face/Scenario-PortraitProcessing/java/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.azure:azure-ai-vision-face:1.0.0-beta.1'
+    implementation 'com.azure:azure-ai-vision-face:1.0.0-beta.2'
     implementation 'com.microsoft.onnxruntime:onnxruntime:1.19.0'
 }
 

--- a/face/Scenario-PortraitProcessing/python/program.py
+++ b/face/Scenario-PortraitProcessing/python/program.py
@@ -21,9 +21,9 @@ MAX_IMAGE_SIZE = 1920
 # JPEG quality
 JPEG_QUALITY = 95
 # Detection model option
-DETECTION_MODEL = FaceDetectionModel.DETECTION_03
+DETECTION_MODEL = FaceDetectionModel.DETECTION03
 # Recognition model option
-RECO_MODEL = FaceRecognitionModel.RECOGNITION_04
+RECO_MODEL = FaceRecognitionModel.RECOGNITION04
 # Face attribute options
 FACE_ATTRIBUTES = [FaceAttributeTypeDetection03.BLUR, FaceAttributeTypeDetection03.HEAD_POSE, FaceAttributeTypeDetection03.MASK, FaceAttributeTypeRecognition04.QUALITY_FOR_RECOGNITION]
 # Margin ratio on face crop


### PR DESCRIPTION

Recently we released a newer package of Azure SDK for face service:

| Language | SDK | Pull Request | Version Change|
| :- | :- | :- | :- |
| C# | [Azure.AI.Vision.Face](https://www.nuget.org/packages/Azure.AI.Vision.Face) | https://github.com/Azure/azure-sdk-for-net/pull/45402 | [1.0.0-beta.1 ➡️ 1.0.0-beta.2](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/face/Azure.AI.Vision.Face/CHANGELOG.md#100-beta2-2024-10-23) |
| Python | [azure.ai.vision.face](https://pypi.org/project/azure.ai.vision.face) | https://github.com/Azure/azure-sdk-for-python/pull/37044 | [1.0.0b1 ➡️ 1.0.0b2](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/face/azure-ai-vision-face/CHANGELOG.md#100b2-2024-10-23) |
| Java | [com.azure:azure-ai-vision-face](https://central.sonatype.com/artifact/com.azure/azure-ai-vision-face) | https://github.com/Azure/azure-sdk-for-java/pull/41823<br>https://github.com/Azure/azure-sdk-for-java/pull/42239 | [1.0.0-beta.1 ➡️ 1.0.0-beta.2](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/face/azure-ai-vision-face/CHANGELOG.md#100-beta2-2024-10-23) |

Bump the lib versions and address the breaking changes (e.g., enum rename) for AndroidDetect, DemoWPF, and PortraitProcessing samples.
